### PR TITLE
use the gnip api subdomain instead of the streaming subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ There are two ways you can provide credentials to the gnip-api gem.
 
 * Pass them to the initialize method
 
-  `Gnip::Rules.new( "chieflarl@larlbang.com", "larl!operator" ,'https://stream.gnip.com/.../YOUR_ACCOUNT/.../prod' )`
+  `Gnip::Rules.new( "chieflarl@larlbang.com", "larl!operator" ,'https://api.gnip.com/.../YOUR_ACCOUNT/.../prod' )`
 
 * Via a configuration file at config/gnip.yml 
 
@@ -22,7 +22,7 @@ There are two ways you can provide credentials to the gnip-api gem.
  development: &development
    username: chieflarl@larlbang.com
    password: larl!operator 
-   streaming_url:'https://stream.gnip.com:443/accounts/YOUR_ACCOUNT/publishers/twitter/streams/track/prod'
+   api_url:'https://api.gnip.com:443/accounts/YOUR_ACCOUNT/publishers/twitter/streams/track/prod'
 ```
 
 ## Usage

--- a/lib/gnip-rules.rb
+++ b/lib/gnip-rules.rb
@@ -15,7 +15,7 @@ module Gnip
         load_credentials!
         username = @config["username"]
         password = @config["password"]
-        uri = uri || @config["streaming_url"]
+        uri = uri || @config["api_url"]
       end
 
       self.class.basic_auth username , password 
@@ -55,7 +55,7 @@ module Gnip
               username: omg@omg.com 
               password: larl! 
               account: larloperator
-              streaming_url: 'https://stream.gnip.com:443/accounts/YOUR_ACCOUNT/publishers/twitter/streams/track/prod/'
+              api_url: 'https://api.gnip.com/accounts/YOUR_ACCOUNT/publishers/twitter/streams/track/prod/'
 
         RUBY
         )


### PR DESCRIPTION
Hey, the official rules endpoint is on api.gnip.com. Managing rules through stream.gnip.com is deprecated. For more information about Gnip's Rules API checkout our documentation.

http://docs.gnip.com/w/page/23733233/Rules%20Methods%20Documentation#AddingRules
