### PR TITLE
Make success? to correspond to all 2xx codes

### DIFF
--- a/lib/gnip-rules/response.rb
+++ b/lib/gnip-rules/response.rb
@@ -45,7 +45,7 @@ module Gnip
     end
 
     def success?
-      ok?
+      ok? || created?
     end
 
     def error


### PR DESCRIPTION
I suggest to have `success?` to indicate the success of not only GET or DELETE operations, but also POST (submit rules).
